### PR TITLE
add email validator to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ bcrypt==3.2.0
 cffi==1.14.4
 click==7.1.2
 dnspython==2.0.0
+email-validator==1.1.2
 Flask==1.1.2
 Flask-Bcrypt==0.7.1
 Flask-Login==0.5.0


### PR DESCRIPTION
Fix email_validator pip install requirement. Needed by wtforms